### PR TITLE
added interactive plotting for targplot and tune_kids

### DIFF
--- a/kidPy.py
+++ b/kidPy.py
@@ -27,6 +27,7 @@ import matplotlib.pyplot as plt
 from scipy import signal, ndimage, fftpack
 import find_kids_interactive as fk
 import pygetdata as gd
+import targplot
 plt.ion()
 
 ################################################################
@@ -507,11 +508,11 @@ def plotVNASweep(path):
     plt.savefig(os.path.join(path,'vna_sweep.png'), dpi = 100, bbox_inches = 'tight')
     return
 """
-def plotTargSweep(path):
+def plotTargSweep(path,interactive = True):
     """Plots the results of a TARG sweep
        inputs:
            path: Absolute path to where sweep data is saved"""
-    plt.figure()
+   
     Is, Qs = openStoredSweep(path)
     sweep_freqs = np.load(path + '/sweep_freqs.npy')
     bb_freqs = np.load(path + '/bb_freqs.npy')
@@ -527,13 +528,17 @@ def plotTargSweep(path):
     #bb_freqs = np.concatenate(bb_freqs[len(b_freqs)/2:],bb_freqs[:len(bb_freqs)/2]))
     chan_freqs = np.concatenate((chan_freqs[len(chan_freqs)/2:],chan_freqs[:len(chan_freqs)/2]))
     new_targs = [chan_freqs[chan][np.argmin(mags[chan])] for chan in range(channels)]
-    for chan in range(channels):
-        plt.plot(chan_freqs[chan],mags[chan])
-    plt.title(path, size = 16)
-    plt.xlabel('frequency (MHz)', size = 16)
-    plt.ylabel('dB', size = 16)
-    plt.tight_layout()
-    plt.savefig(os.path.join(path,'targ_sweep.png'), dpi = 100, bbox_inches = 'tight')
+    if interactive:
+	ip = targplot.interactive_plot(Is,Qs,chan_freqs)
+    else:
+	plt.figure()
+    	for chan in range(channels):
+            plt.plot(chan_freqs[chan],mags[chan])
+    	plt.title(path, size = 16)
+    	plt.xlabel('frequency (MHz)', size = 16)
+    	plt.ylabel('dB', size = 16)
+    	plt.tight_layout()
+    	plt.savefig(os.path.join(path,'targ_sweep.png'), dpi = 100, bbox_inches = 'tight')
     return
 
 def plotLastVNASweep():

--- a/scripts/tune_max_didq.py
+++ b/scripts/tune_max_didq.py
@@ -5,4 +5,4 @@ import numpy as np
 #of the resonator. Run target sweep before this
 
 filename = str(np.load("last_targ_dir.npy"))
-tune_kids.tune_kids(filename,ri,regs,fpga,min = False)
+tune_kids.tune_kids(filename,ri,regs,fpga,find_min = False,interactive = True,look_around = 30)

--- a/scripts/tune_min.py
+++ b/scripts/tune_min.py
@@ -5,4 +5,4 @@ import numpy as np
 #of the resonator. Run target sweep before this
 
 filename = str(np.load("last_targ_dir.npy"))
-tune_kids.tune_kids(filename,ri,regs,fpga)
+tune_kids.tune_kids(filename,ri,regs,fpga,interactive = True,look_around = 25)

--- a/targplot.py
+++ b/targplot.py
@@ -1,0 +1,51 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+class interactive_plot(object):
+
+    def __init__(self,Is,Qs,chan_freqs):
+	self.Is = Is
+	self.Qs = Qs
+	self.chan_freqs = chan_freqs
+        self.fig = plt.figure(1,figsize = (13,6))
+        self.ax = self.fig.add_subplot(121)
+	self.ax.set_ylabel("Power (dB)")
+	self.ax.set_xlabel("Frequecy (MHz)")
+        self.ax2 = self.fig.add_subplot(122)
+	self.ax2.set_ylabel("Q")
+	self.ax2.set_xlabel("I")
+        self.fig.canvas.mpl_connect('key_press_event', self.on_key_press)
+        #self.fig.canvas.mpl_connect('key_release_event', self.on_key_release)
+        #self.fig.canvas.mpl_connect('button_press_event', self.onClick)
+        self.plot_index = 0
+	self.l1, = self.ax.plot(chan_freqs[self.plot_index,:],10*np.log10(Is[:,self.plot_index]**2+Qs[:,self.plot_index]**2),'o')
+	self.l2, = self.ax2.plot(Is[:,self.plot_index],Qs[:,self.plot_index],'o')
+	self.ax.set_title("Resonator Index "+str(self.plot_index))
+	print("")
+        print("Interactive Target Sweep Plotting Activated")
+        print("Use left and right arrows to switch between resonators")
+	plt.show(block = True)
+
+    def refresh_plot(self):
+        self.l1.set_data(self.chan_freqs[self.plot_index,:],10*np.log10(self.Is[:,self.plot_index]**2+self.Qs[:,self.plot_index]**2))
+        self.ax.relim()
+        self.ax.autoscale()
+        self.ax.set_title("Resonator Index "+str(self.plot_index))
+	self.l2.set_data(self.Is[:,self.plot_index],self.Qs[:,self.plot_index])
+        self.ax2.relim()
+        self.ax2.autoscale()
+        plt.draw()
+        
+    def on_key_press(self, event):
+        #print event.key
+        if event.key == 'right':
+           if self.plot_index != self.chan_freqs.shape[0]-1:
+    		self.plot_index = self.plot_index +1
+		self.refresh_plot()
+
+        if event.key == 'left':
+           if self.plot_index != 0:
+    		self.plot_index = self.plot_index -1
+		self.refresh_plot()
+
+

--- a/tune_kids.py
+++ b/tune_kids.py
@@ -1,4 +1,5 @@
 import numpy as np
+import matplotlib.pyplot as plt
 from kidPy import openStoredSweep
 import os
 
@@ -22,25 +23,124 @@ def read_iq_sweep(filename):
 	iq_dict = {'I': I, 'Q': Q, 'freqs': chan_freqs}
 	return iq_dict
 
-def tune_kids(filename,ri,regs,fpga,min = True):
+def find_max_didq(Is,Qs,look_around):
+	pos_offset_I = np.roll(Is,1,axis = 0)
+	neg_offset_I = np.roll(Is,-1,axis = 0)
+	pos_offset_Q = np.roll(Qs,1,axis = 0)
+	neg_offset_Q = np.roll(Qs,-1,axis = 0)
+	pos_dist= np.sqrt((Is-pos_offset_I)**2+(Qs-pos_offset_Q)**2)
+	neg_dist= np.sqrt((Is-neg_offset_I)**2+(Qs-neg_offset_Q)**2)
+	ave_dist = (pos_dist + neg_dist)/2.
+	#zero out the last and first values
+	ave_dist[0,:] = 0
+	ave_dist[ave_dist.shape[0]-1,:] = 0
+	min_index = np.argmax(ave_dist[Is.shape[0]/2-look_around:Is.shape[0]/2+look_around],axis =0)+(Is.shape[0]/2-look_around)
+	return min_index	
+
+
+class interactive_plot(object):
+
+    def __init__(self,Is,Qs,chan_freqs,look_around,find_min = True):
+	self.find_min = find_min
+	self.Is = Is
+	self.Qs = Qs
+	self.chan_freqs = chan_freqs
+	self.targ_size = chan_freqs.shape[0]
+	self.look_around = look_around
+        self.plot_index = 0
+	if self.find_min:
+		self.min_index = np.argmin(self.Is[self.targ_size/2-self.look_around:self.targ_size/2+self.look_around]**2+self.Qs[self.targ_size/2-self.look_around:self.targ_size/2+look_around]**2,axis = 0) +(self.targ_size/2-look_around)
+	else:
+		self.min_index = find_max_didq(self.Is,self.Qs,self.look_around)
+        self.fig = plt.figure(1,figsize = (13,6))
+        self.ax = self.fig.add_subplot(121)
+	self.ax.set_ylabel("Power (dB)")
+	self.ax.set_xlabel("Frequecy (MHz)")
+        self.ax2 = self.fig.add_subplot(122)
+	self.ax2.set_ylabel("Q")
+	self.ax2.set_xlabel("I")
+        self.fig.canvas.mpl_connect('key_press_event', self.on_key_press)
+        #self.fig.canvas.mpl_connect('key_release_event', self.on_key_release)
+        #self.fig.canvas.mpl_connect('button_press_event', self.onClick)
+	self.l1, = self.ax.plot(self.chan_freqs[:,self.plot_index],10*np.log10(self.Is[:,self.plot_index]**2+self.Qs[:,self.plot_index]**2),'o')
+	self.l2, = self.ax2.plot(self.Is[:,self.plot_index],Qs[:,self.plot_index],'o')
+	self.p1, = self.ax.plot(self.chan_freqs[self.min_index[self.plot_index],self.plot_index],10*np.log10(self.Is[self.min_index[self.plot_index],self.plot_index]**2+self.Qs[self.min_index[self.plot_index],self.plot_index]**2),'*',markersize = 15)
+	self.p2, = self.ax2.plot(self.Is[self.min_index[self.plot_index],self.plot_index],self.Qs[self.min_index[self.plot_index],self.plot_index],'*',markersize = 15)
+	self.ax.set_title("Resonator Index "+str(self.plot_index))
+	self.ax2.set_title("Look Around Points "+str(self.look_around))
+	print("")
+        print("Interactive Resonance Tuning Activated")
+        print("Use left and right arrows to switch between resonators")
+	print("Use the up and down arrows to change look around points")
+	plt.show(block = True)
+
+    def refresh_plot(self):
+        self.l1.set_data(self.chan_freqs[:,self.plot_index],10*np.log10(self.Is[:,self.plot_index]**2+self.Qs[:,self.plot_index]**2))
+	self.p1.set_data(self.chan_freqs[self.min_index[self.plot_index],self.plot_index],10*np.log10(self.Is[self.min_index[self.plot_index],self.plot_index]**2+self.Qs[self.min_index[self.plot_index],self.plot_index]**2))
+        self.ax.relim()
+        self.ax.autoscale()
+        self.ax.set_title("Resonator Index "+str(self.plot_index))
+	self.ax2.set_title("Look Around Points "+str(self.look_around))
+	self.l2.set_data((self.Is[:,self.plot_index],self.Qs[:,self.plot_index]))
+	self.p2.set_data(self.Is[self.min_index[self.plot_index],self.plot_index],self.Qs[self.min_index[self.plot_index],self.plot_index])
+        self.ax2.relim()
+        self.ax2.autoscale()
+        plt.draw()
+        
+    def on_key_press(self, event):
+        #print event.key
+        if event.key == 'right':
+           if self.plot_index != self.chan_freqs.shape[1]-1:
+    		self.plot_index = self.plot_index +1
+		self.refresh_plot()
+
+        if event.key == 'left':
+           if self.plot_index != 0:
+    		self.plot_index = self.plot_index -1
+		self.refresh_plot()
+
+        if event.key == 'up':
+           if self.look_around != self.chan_freqs.shape[0]/2:
+    		self.look_around = self.look_around +1
+		if self.find_min:
+			self.min_index = np.argmin(self.Is[self.targ_size/2-self.look_around:self.targ_size/2+self.look_around]**2+self.Qs[self.targ_size/2-self.look_around:self.targ_size/2+self.look_around]**2,axis = 0)+(self.targ_size/2-self.look_around)
+		else:
+			self.min_index = find_max_didq(self.Is,self.Qs,self.look_around)
+		self.refresh_plot()
+
+        if event.key == 'down':
+           if self.look_around != 1:
+    		self.look_around = self.look_around -1
+		if self.find_min:
+			self.min_index = np.argmin(self.Is[self.targ_size/2-self.look_around:self.targ_size/2+self.look_around]**2+self.Qs[self.targ_size/2-self.look_around:self.targ_size/2+self.look_around]**2,axis = 0)+(self.targ_size/2-self.look_around)
+		else:
+			self.min_index = find_max_didq(self.Is,self.Qs,self.look_around)
+		self.refresh_plot()
+
+
+def tune_kids(filename,ri,regs,fpga,find_min = True,interactive = False, **kwargs):
 	iq_dict = read_iq_sweep(filename)
-	if min: #fine the minimum
+	if "look_around" in kwargs:
+		print("you are using "+str(kwargs['look_around'])+" look around points")
+		look_around = kwargs['look_around']
+	else:
+		look_around = iq_dict['freqs'].shape[0]/2
+	if find_min: #fine the minimum
 		print("centering on minimum")
-		min_indx = np.argmin(iq_dict['I']**2+iq_dict['Q']**2,axis = 0)
-		new_freqs = iq_dict['freqs'][(min_indx,np.arange(0,iq_dict['freqs'].shape[1]))]
+		if interactive:
+			ip = interactive_plot(iq_dict['I'],iq_dict['Q'],iq_dict['freqs'],look_around)
+			new_freqs = iq_dict['freqs'][(ip.min_index,np.arange(0,iq_dict['freqs'].shape[1]))]
+		else:
+			min_index = np.argmin(iq_dict['I']**2+iq_dict['Q']**2,axis = 0)
+			new_freqs = iq_dict['freqs'][(min_index,np.arange(0,iq_dict['freqs'].shape[1]))]
 	else: # find the max of dIdQ
 		print("centering on max dIdQ")
-		pos_offset_I = np.roll(iq_dict['I'],1,axis = 0)
-		neg_offset_I = np.roll(iq_dict['I'],-1,axis = 0)
-		pos_offset_Q = np.roll(iq_dict['Q'],1,axis = 0)
-		neg_offset_Q = np.roll(iq_dict['Q'],-1,axis = 0)
-		pos_dist= np.sqrt((iq_dict['I']-pos_offset_I)**2+(iq_dict['Q']-pos_offset_Q)**2)
-		neg_dist= np.sqrt((iq_dict['I']-neg_offset_I)**2+(iq_dict['Q']-neg_offset_Q)**2)
-		ave_dist = (pos_dist - neg_dist)/2.
-		#zero out the last and first values
-		ave_dist[0,:] = 0
-		ave_dist[ave_dist.shape[0]-1,:] = 0
-		new_freqs = iq_dict['freqs'][(np.argmax(ave_dist,axis =0),np.arange(0,iq_dict['freqs'].shape[1]))]
+		if interactive:
+			ip = interactive_plot(iq_dict['I'],iq_dict['Q'],iq_dict['freqs'],look_around,find_min = False)
+			new_freqs = iq_dict['freqs'][(ip.min_index,np.arange(0,iq_dict['freqs'].shape[1]))]
+		else:
+			min_index = find_max_didq(iq_dict['I'],iq_dict['Q'],look_around)
+			new_freqs = iq_dict['freqs'][(min_index,np.arange(0,iq_dict['freqs'].shape[1]))]
 	new_bb_freqs = (new_freqs*10**6-ri.center_freq*10**6)
 	if not np.size(ri.freq_comb):
 		try:


### PR DESCRIPTION


I added an interactive plot option for targetplot so that
you have zoomed in plots of each resonator that you can
switch between with the right and left arrow keys.
I also added a similar functionality to the tune_kids.py
program. in that one you can also use the up down keys
to changed the number of look around points for finding
either the max of didq or the min of the resonator. This
is useful if you have some collisions and just want to
search only far enough. When I did this I also discovered
several bugs that effecivily made the tune_max_didq.py
not functional. In the past it was probably just still
tuning to the minimum of the resonator.