### PR TITLE
Caltech devel

### DIFF
--- a/gbeConfig.py
+++ b/gbeConfig.py
@@ -72,7 +72,11 @@ def writer(q, filename, start_chan, end_chan): #Haven't tested recently, but as
         if q_data is not None:
             data, packet_count, ts = q_data
             for idx, chan in enumerate(range(start_chan, end_chan + 1)):
-                I, Q, __ = parseChanData(chan, data)
+                #I, Q, __ = parseChanData(chan, data)
+                #the function call to parseChanData was providing a botleneck
+                #for streaming with large number of channels(found with 166)
+                I = data[1024 * (chan % 2) + (chan // 2)]
+                Q = data[512 + 1024 * (chan % 2) + (chan // 2)]
                 fo_I[idx].write(struct.pack('d', I))
                 fo_Q[idx].write(struct.pack('d', Q))
             fo_count.write(struct.pack('L',packet_count))

--- a/gbeConfig.py
+++ b/gbeConfig.py
@@ -26,6 +26,7 @@ import errno
 import pygetdata as gd
 
 
+
 def parseChanData(chan, data):
     """Parses packet data into I, Q, and phase
        inputs:
@@ -46,6 +47,9 @@ def parseChanData(chan, data):
 def writer(q, filename, start_chan, end_chan): #Haven't tested recently, but as 
     #of a few years ago, functions passed to multiprocessing need to be top
     #level functions
+    pid = os.getpid()
+    cmd = "renice -n 19 -p "+str(pid)
+    os.system(cmd)#renice the writer so it doesn't eat up cpu from the packet grabber
     chan_range = range(start_chan, end_chan + 1)
     nfo_I = map(lambda z: filename + "/I_" + str(z), chan_range)
     nfo_Q = map(lambda z: filename + "/Q_" + str(z), chan_range)
@@ -67,6 +71,7 @@ def writer(q, filename, start_chan, end_chan): #Haven't tested recently, but as
     fo_time = open(filename + "/time", "ab")
     fo_count = open(filename + "/packet_count", "ab")
     streaming = True
+    count = 0
     while streaming:
         q_data = q.get()
         if q_data is not None:
@@ -75,8 +80,8 @@ def writer(q, filename, start_chan, end_chan): #Haven't tested recently, but as
                 #I, Q, __ = parseChanData(chan, data)
                 #the function call to parseChanData was providing a botleneck
                 #for streaming with large number of channels(found with 166)
-                I = data[1024 * (chan % 2) + (chan // 2)]
-                Q = data[512 + 1024 * (chan % 2) + (chan // 2)]
+                I = data[(chan % 2) * 1024 + (chan / 2)]
+                Q = data[512 + (chan % 2) * 1024 + (chan / 2)]
                 fo_I[idx].write(struct.pack('d', I))
                 fo_Q[idx].write(struct.pack('d', Q))
             fo_count.write(struct.pack('L',packet_count))
@@ -88,7 +93,15 @@ def writer(q, filename, start_chan, end_chan): #Haven't tested recently, but as
             for idx in range(len(fo_I)):
                 fo_I[idx].flush()
                 fo_Q[idx].flush()
-
+        count += 1
+        if count % 1000 == 0:
+            fo_count.flush()
+            fo_time.flush()
+            for idx in range(len(fo_I)):
+                fo_I[idx].flush()
+                fo_Q[idx].flush()
+        if count % 3000 == 0:
+            print(q.qsize())
 
     for idx in range(len(fo_I)):
          fo_I[idx].close()
@@ -126,6 +139,7 @@ class roachDownlink(object):
         self.udp_destmac1 = int(dest_mac[0:4], 16)
         self.udp_destmac0 = int(dest_mac[4:], 16)
 
+        
     def configSocket(self):
         """Configure socket parameters"""
         try:
@@ -133,6 +147,7 @@ class roachDownlink(object):
             #get max buffer size, buffers are good for not dropping packets
             with open('/proc/sys/net/core/rmem_max', 'r') as f:
                 buf_max = int(f.readline())
+            self.buf_max = buf_max
             self.s.setsockopt(sock.SOL_SOCKET, sock.SO_RCVBUF, buf_max)
             self.s.bind((self.gc[np.where(self.gc == 'udp_dest_device')[0][0]][1], 3))
         except sock.error, v:
@@ -142,6 +157,19 @@ class roachDownlink(object):
                 pass
         return
 
+    def empty_buffer(self):
+        count = 0
+        while True:
+            read,write,error = select.select([self.s],[],[],0)
+            if len(read) == 0: #buffer empty
+                #print("buffer emptied it contained")
+                #print(count)
+                #print("packets")
+                break
+            for s in read: packet = self.s.recv(self.buf_size)
+            count = count+1
+
+    
     def configDownlink(self):
         """Configure GbE parameters"""
         
@@ -183,6 +211,7 @@ class roachDownlink(object):
             for s in read:
                 packet = self.s.recv(self.buf_size)
                 if len(packet) != self.buf_size:
+                    print('{0} / {1}'.format(len(packet), self.buf_size))
                     packet = []
         return packet
 
@@ -210,15 +239,17 @@ class roachDownlink(object):
         time.sleep(0.1)
         return
 
-    def parsePacketData(self):
+    def parsePacketData(self, packet=False):
         """Parses packet data, filters reception based on source IP
            outputs:
                packet: The original data packet
                float data: Array of channel data
                header: String packed IP/ETH header
                saddr: The packet source address"""
-        packet = self.waitForData()
+        if packet is not None and not packet:
+            packet = self.waitForData()
         if not packet:
+            print "no packet"
             print "Non-Roach packet received"
             return
         data = np.fromstring(packet[self.header_len:], dtype = '<i').astype('float')
@@ -227,6 +258,7 @@ class roachDownlink(object):
         saddr = sock.inet_ntoa(saddr) # source addr
         ### Filter on source IP ###
         if (saddr != self.gc[np.where(self.gc == 'udp_src_ip')[0][0]][1]):
+            print "wrong address"
             print "Non-Roach packet received"
             return
         return packet, data, header, saddr
@@ -338,7 +370,7 @@ class roachDownlink(object):
             previous_idx = packet_count
         return
 
-    def saveSweepData(self, Navg, savepath, lo_freq, Nchan, skip_packets = 0):
+    def saveSweepData(self, Navg, savepath, lo_freq, Nchan, skip_packets = None):
         """Saves sweep data as .npy in path specified at savepath
            inputs:
                int Navg: Number of data points to average at each sweep step
@@ -351,15 +383,18 @@ class roachDownlink(object):
         Q_buffer = np.empty((Navg + skip_packets, Nchan))
         self.zeroPPS()
         count = 0
+        self.empty_buffer()
         while count < Navg + skip_packets:
             try:
                 packet, data, header, saddr = self.parsePacketData()
                 if not packet:
                     print "Packet error"
-                    return -1
+                    #return -1
+                    continue #skip that packet
                 if not np.size(data):
                     print "Packet error"
-                    return -1
+                    #return -1
+                    continue #skip that packet
                 odd_chan = channels[1::2]
                 even_chan = channels[0::2]
                 I_odd = data[1024 + ((odd_chan - 1) / 2)]
@@ -382,14 +417,15 @@ class roachDownlink(object):
                     Q = np.hstack(zip(Q_even, Q_odd))
                 I_buffer[count] = I
                 Q_buffer[count] = Q
-                count += 1
                 I_file = 'I' + str(lo_freq)
                 Q_file = 'Q' + str(lo_freq)
                 np.save(os.path.join(savepath,I_file), np.mean(I_buffer[skip_packets:], axis = 0))
                 np.save(os.path.join(savepath,Q_file), np.mean(Q_buffer[skip_packets:], axis = 0))
+                count += 1
             except TypeError:
                 print "Packet error"
-                return -1
+                #return -1
+                continue
         return 0
 
     def saveDirfile_adcIQ(self, time_interval):
@@ -486,17 +522,26 @@ class roachDownlink(object):
         return
 
 
-    def saveDirfile_chanRangeIQ(self, time_interval, stage_coords = False):
+    def saveDirfile_chanRangeIQ(self, time_interval, stage_coords = False, **keywords):
         """Saves a dirfile containing the I and Q values for a range of channels, streamed
            over a time interval specified by time_interval
            inputs:
                float time_interval: Time interval to integrate over, seconds
                bool stage_coords: Currently deprecated, to be used when beam mapping"""
-        start_chan = input("Start chan # ? ")
-        end_chan = input("End chan # ? ")
+        if ('start_chan' in keywords):
+            start_chan = keywords['start_chan']
+        else:
+            start_chan = input("Start chan # ? ")
+        if ('end_chan' in keywords):
+            end_chan = keywords['end_chan']
+        else:
+            end_chan = input("End chan # ? ")
         chan_range = range(start_chan, end_chan + 1)
-        data_path = self.gc[np.where(self.gc == 'DIRFILE_SAVEPATH')[0][0]][1] 
-        sub_folder = raw_input("Insert subfolder name (e.g. single_tone): ")
+        data_path = self.gc[np.where(self.gc == 'DIRFILE_SAVEPATH')[0][0]][1]
+        if ('sub_folder' in keywords):
+            sub_folder = keywords['sub_folder']
+        else:
+            sub_folder = raw_input("Insert subfolder name (e.g. single_tone): ")
         Npackets = int(np.ceil(time_interval * self.data_rate))
         self.zeroPPS()
         save_path = os.path.join(data_path, sub_folder)
@@ -510,9 +555,9 @@ class roachDownlink(object):
         pool = mp.Pool(1)
         write_Q = manager.Queue()
         pool.apply_async(writer, (write_Q, filename, start_chan, end_chan))
-
         try:
             count = 0
+            self.empty_buffer()
             while count < Npackets:
                 ts = time.time()
                 try:
@@ -522,7 +567,7 @@ class roachDownlink(object):
                 #### Add field for stage coords ####
                 except TypeError:
                     continue
-                packet_count = (np.fromstring(packet[-4:],dtype = '>I'))
+                packet_count = (np.fromstring(packet[-8:-4],dtype = '>I'))
                 write_Q.put((data, packet_count, ts))
                 count += 1
         except KeyboardInterrupt:

--- a/scripts/fine_gain.py
+++ b/scripts/fine_gain.py
@@ -1,6 +1,8 @@
 # this script takes a fine scan and gain scan combo
 #then analyzes it if you like
 # below module found at https://github.com/GlennGroupUCB/submm_python_routines.git
+import subprocess
+import sys
 from multitone_kidPy import analyze 
 fit_scans = True
 
@@ -9,13 +11,13 @@ print("Running fine scan and gain scan combo")
 #gain scan 
 #run gain scan first so you don't acidentially recenter
 #on the gain scan afterwords instead of the fine scan
-targetSweep(ri, udp, valon,span = 1.26e6,lo_step = 1.26e6/90.)
+targetSweep(ri, udp, valon,span = 2.0e6,lo_step = 2.0e6/50.)
 gain_name = str(np.load("last_targ_dir.npy"))
-plotTargSweep(gain_name)
+#plotTargSweep(gain_name)
 #fine scan
-targetSweep(ri, udp, valon,span = (100*.4*1000),lo_step = .4e3)
+targetSweep(ri, udp, valon,span = (50.*1000),lo_step = 0.5e3)
 fine_name = str(np.load("last_targ_dir.npy"))
-plotTargSweep(fine_name)
+#plotTargSweep(fine_name)
 
 
 plt.close('all')
@@ -24,7 +26,8 @@ print("The gain scan is: " + gain_name)
 
 if fit_scans:
 	plt.ioff() # this causes some error to print to screen but it is better that figures continuously poping up
-	analyze.fit_fine_gain(fine_name,gain_name)
+	#analyze.fit_fine_gain(fine_name,gain_name)
+        p = subprocess.Popen([sys.executable, './scripts/analyze_fine_gain.py',str(fine_name),str(gain_name)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 	plt.ion()
 
 

--- a/scripts/power_sweep.py
+++ b/scripts/power_sweep.py
@@ -7,25 +7,26 @@
 from datetime import datetime
 import subprocess
 import sys
+import os
 
 analyze_on_the_go = True #will use subproccess to start analyzing the data as soon as you take it
 # for Pete becuase he likes things to be fast
 
 from lab_brick import core #this module can be found https://github.com/GlennGroupUCB/submm_python_routines.git
-power_sweep_dir = "../data/power_sweeps/"
+power_sweep_dir = "../../data/kidpy_multitone/power_sweeps/"
 
 #you will need to edit the last number below to be the serial number of your lab brick
-attn = core.Attenuator(0x041f,0x1208,"16776")
-max_attn = 26.
-min_attn = 16.
-attn_step = 1.
+attn = core.Attenuator(0x041f,0x1208,"01784")
+max_attn = 32.
+min_attn = 4.
+attn_step = 2.
 n_attn_levels = np.int((max_attn-min_attn)/attn_step)+1
 
 attn_levels = np.linspace(max_attn,min_attn,n_attn_levels)
 
-fine_step = 0.4e3
-fine_span = 100*0.4e3
-gain_span = 1.2e6
+fine_step = 0.5e3
+fine_span = 50*1e3
+gain_span = 2.0e6
 gain_step = gain_span/50.
 
 fine_names = []
@@ -37,16 +38,16 @@ for i in range(0,n_attn_levels):
 	#take gain scan
 	targetSweep(ri, udp, valon,span = gain_span,lo_step = gain_step)
 	gain_name = str(np.load("last_targ_dir.npy")) 
-	gain_names.append(gain_name)
+	gain_names.append(os.path.abspath(gain_name))
 	#take fine scan
 	targetSweep(ri, udp, valon,span = fine_span,lo_step = fine_step)
 	fine_name = str(np.load("last_targ_dir.npy"))
-	fine_names.append(fine_name)
+	fine_names.append(os.path.abspath(fine_name))
 	#here you might consider recentering tones
 	if analyze_on_the_go: #analyze on the fly to make things faster
 		p = subprocess.Popen([sys.executable, './scripts/analyze_fine_gain.py',str(fine_name),str(gain_name)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 	
-
+attn.connected = False
 time_str = str(datetime.now())[0:10]+str(datetime.now())[11:19]
 np.save(power_sweep_dir+ time_str+"_fine_names",fine_names)
 np.save(power_sweep_dir+ time_str+"_gain_names",gain_names)

--- a/scripts/take_noise_set.py
+++ b/scripts/take_noise_set.py
@@ -1,0 +1,15 @@
+
+targetSweep(ri, udp, valon,span = 2.0e6,lo_step = 2.0e6/50.)
+gain_name = str(np.load("last_targ_dir.npy"))
+#plotTargSweep(gain_name)
+#fine scan
+targetSweep(ri, udp, valon,span = (50.*1000),lo_step = 0.5e3)
+fine_name = str(np.load("last_targ_dir.npy"))
+#plotTargSweep(fine_name)
+
+#plt.close('all')
+print("The fine scan is: " + fine_name)
+print("The gain scan is: " + gain_name)
+file_name = "noise_"+time.strftime("%Y%m%d_%H%M%S")
+
+udp.saveDirfile_chanRangeIQ(600,start_chan = 0,end_chan = 165,sub_folder = file_name)

--- a/scripts/take_noise_set_multi.py
+++ b/scripts/take_noise_set_multi.py
@@ -1,0 +1,42 @@
+import tune_kids
+import numpy as np
+
+
+sets = 6
+gain_names = []
+fine_names = []
+fine_names_2 = []
+stream_names = []
+
+for i in range(0,sets):
+    print("Starting set "+ str(i))
+    targetSweep(ri, udp, valon,span = 2.0e6,lo_step = 2.0e6/50.)
+    gain_name = str(np.load("last_targ_dir.npy"))
+    gain_names.append(gain_name)
+    #plotTargSweep(gain_name)
+    #fine scan
+    targetSweep(ri, udp, valon,span = (30.*1000),lo_step = 0.3e3)
+    fine_name = str(np.load("last_targ_dir.npy"))
+    fine_names.append(fine_name)
+    #plotTargSweep(fine_name)
+
+    #plt.close('all')
+    print("The fine scan is: " + fine_name)
+    print("The gain scan is: " + gain_name)
+    file_name = "noise_"+time.strftime("%Y%m%d_%H%M%S")
+    stream_names.append(file_name)
+    udp.saveDirfile_chanRangeIQ(600,start_chan = 0,end_chan = 165,sub_folder = file_name)
+    targetSweep(ri, udp, valon,span = (30.*1000),lo_step = 0.3e3)
+    fine_name_2 = str(np.load("last_targ_dir.npy"))
+    fine_names_2.append(fine_name_2)
+    #recenter the tones
+    tune_kids.tune_kids(fine_name_2,ri,regs,fpga,find_min = False,interactive = False,look_around = 10)
+
+file_prefix = "../../noise_sets/"
+time_str = time.strftime("%Y%m%d_%H%M%S")
+np.save(file_prefix+"noise_fine_names"+time_str,fine_names)
+np.save(file_prefix+"noise_gain_names"+time_str,gain_names)
+np.save(file_prefix+"noise_fine_2_names"+time_str,fine_names_2)
+np.save(file_prefix+"noise_stream_names"+time_str,stream_names)
+                      
+        


### PR DESCRIPTION
There are a few updates here but the most important is that we 
added in clearing buffer of old packets plus other stuff  …
We had recently added code that initializes the buffer as the max buffer
size for the computer. This is good for not dropping packets
The issue with this was when you took a new
measurement there would be old data left in the buffer from much
earlier that you would want to throw away. To make matters worse
in order to stop dropping packets at caltech I had to make the
default buffer for Linux very big ~3000 packets. We were kind of
dealing with this by using the skip_packets keyword. but when the
buffer is large this becomes impractical because you dont want to
read in the 3000 new packets to get to the relavent data when doing
an IQ sweep. So I added function to clear the buffer of old packets
quickly and now it is called every time before taking data.

For detail on this see the wiki where I documented dropping packets
https://github.com/sbg2133/kidPy/wiki/Instructions

A few other additions were made to let you have a custom noise
stream script.

Also the indexing for packet_count was outdated in that function
so it was updated.

Finally, the parallel process that writes the streaming to disk
is reniced so that it doesn't compete with the grabbing packet
process.

-Jordan